### PR TITLE
Chat user search

### DIFF
--- a/controllers/chat.js
+++ b/controllers/chat.js
@@ -70,7 +70,7 @@ exports.getChats = (req, res) => {
 };
 
 exports.createChat = async (req, res, next) => {
-  let user = await User.findOne({ name: req.body.who })
+  let user = await User.findOne({ name: req.body.who.toLowerCase() })
 
   if (!user) {
     return res.status(400).json({ error: "User not found" })


### PR DESCRIPTION
force username to lowercase when searching for user
makes case irrelevant 
e.g. typing "TeST" will find user "test" and start chat